### PR TITLE
test: stabilize browser checks

### DIFF
--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -7,7 +7,8 @@ export default defineConfig({
     testDir: './tests/browser',
     testMatch: '**/*.spec.mjs',
     fullyParallel: true,
-    timeout: 10_000,
+    retries: process.env.CI ? 2 : 0,
+    timeout: 30_000,
     use: {
         baseURL: 'http://127.0.0.1:4173',
         browserName: 'chromium',


### PR DESCRIPTION
## Summary
- allow slower CI runners more time to initialize browser fixtures
- retry failed browser tests twice in CI

## Verification
- `CI=1 npm run test:browser -- --workers=1`
- 35 tests passed locally

This PR also establishes the review flow for the browser test fix.