### PR TITLE
fix: guard missing input errors

### DIFF
--- a/resources/views/components/input-group.blade.php
+++ b/resources/views/components/input-group.blade.php
@@ -12,7 +12,9 @@
 $isInline = $attributes->get('inline') || in_array($attributes->get('type'), [ 'checkbox', 'radio', 'range']);
 $errorName = $errorName ?? $name;
 $oldName = $oldName ?? $name;
-$displayErrors = $errors->$errorBag->has($errorName) && !$attributes->has("prevent-errors");
+$displayErrors = isset($errors)
+    && $errors->$errorBag->has($errorName)
+    && !$attributes->has("prevent-errors");
 $inputAttributes = $attributes->whereDoesntStartWith(['label', 'group'])->except('value');
 @endphp
 

--- a/tests/Feature/Components/InteractiveTest.php
+++ b/tests/Feature/Components/InteractiveTest.php
@@ -541,6 +541,17 @@ describe('input group', function () {
         expect($html)->toContain('<label')->toContain('Email')->toContain('<input');
     });
 
+    it('renders when no validation error bag is shared', function () {
+        View::share('errors', null);
+
+        try {
+            expect(renderComponent('input-group', 'name="email"'))
+                ->toContain('name="email"');
+        } finally {
+            View::share('errors', new ViewErrorBag);
+        }
+    });
+
     it('names the input', function () {
         expect(renderComponent('input-group', 'name="email"'))->toContain('name="email"');
     });


### PR DESCRIPTION
## Summary
- guard input groups when no validation error bag is shared
- add regression coverage for standalone Markdown previews

## Checks
- vendor/bin/pest --no-coverage
- vendor/bin/phpstan analyse --no-progress
- vendor/bin/pint ... --test